### PR TITLE
Fix release date formatting by adding dummy month when data is only YYYY

### DIFF
--- a/interface.py
+++ b/interface.py
@@ -242,6 +242,9 @@ class ModuleInterface:
         release_year = album_data.get('release_ymd')[:4] if album_data.get('release_ymd') else None
 
         release_date = album_data.get('release_ymd') if album_data.get('release_ymd') else None
+        # add a month if the month is missing from the YYYY date
+        if len(release_date) == 4:
+            release_date += '01'
         # add a day if the day is missing from the YYYYMM date
         if len(release_date) == 6:
             release_date += '01'


### PR DESCRIPTION
Add a dummy month (01) when data is only YYYY.

Current code fails for tracks with only YYYY:
```
Traceback (most recent call last):
  File "/path/to/OrpheusDL/orpheus.py", line 225, in <module>
    main()
    ~~~~^^
  File "/path/to/OrpheusDL/orpheus.py", line 220, in main
    orpheus_core_download(orpheus, media_to_download, tpm, sdm, path)
    ~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/path/to/OrpheusDL/orpheus/core.py", line 399, in orpheus_core_download
    downloader.download_track(media_id, extra_kwargs=media.extra_kwargs)
    ~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/path/to/OrpheusDL/orpheus/music_downloader.py", line 294, in download_track
    track_info: TrackInfo = self.service.get_track_info(track_id, quality_tier, codec_options, **extra_kwargs)
                            ~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/path/to/OrpheusDL/modules/bugs/interface.py", line 248, in get_track_info
    release_date = datetime.strptime(release_date, '%Y%m%d').strftime('%Y-%m-%d')
                   ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.13/_strptime.py", line 676, in _strptime_datetime
    tt, fraction, gmtoff_fraction = _strptime(data_string, format)
                                    ~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.13/_strptime.py", line 455, in _strptime
    raise ValueError("time data %r does not match format %r" %
                     (data_string, format))
ValueError: time data '1994' does not match format '%Y%m%d'
````

One such failing case is https://music.bugs.co.kr/track/65380.

This commit works fixes the issue by adding a dummy month when month is not present, just as the code currently does for missing dates.